### PR TITLE
support actor send message to itself

### DIFF
--- a/coerce-rt/src/actor/context.rs
+++ b/coerce-rt/src/actor/context.rs
@@ -54,12 +54,17 @@ pub enum ActorStatus {
 }
 
 pub struct ActorHandlerContext {
+    actor_id: ActorId,
     status: ActorStatus,
 }
 
 impl ActorHandlerContext {
-    pub fn new(status: ActorStatus) -> ActorHandlerContext {
-        ActorHandlerContext { status }
+    pub fn new(actor_id: ActorId, status: ActorStatus) -> ActorHandlerContext {
+        ActorHandlerContext { actor_id, status }
+    }
+
+    pub fn actor_id(&self) -> &ActorId {
+        &self.actor_id
     }
 
     pub fn set_status(&mut self, state: ActorStatus) {

--- a/coerce-rt/src/actor/lifecycle.rs
+++ b/coerce-rt/src/actor/lifecycle.rs
@@ -46,7 +46,7 @@ pub async fn actor_loop<A: Actor>(
     A: 'static + Send + Sync,
 {
     trace!(target: "ActorLoop", "[{}] starting", &id);
-    let mut ctx = ActorHandlerContext::new(Starting);
+    let mut ctx = ActorHandlerContext::new(id.clone(), Starting);
 
     actor.started(&mut ctx).await;
 

--- a/coerce-rt/src/actor/mod.rs
+++ b/coerce-rt/src/actor/mod.rs
@@ -88,6 +88,16 @@ pub enum ActorRefError {
     ActorUnavailable,
 }
 
+impl std::fmt::Display for ActorRefError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActorRefError::ActorUnavailable => write!(f, "actor unavailable"),
+        }
+    }
+}
+
+impl std::error::Error for ActorRefError {}
+
 impl<A: Actor> ActorRef<A>
 where
     A: Sync + Send + 'static,


### PR DESCRIPTION
This PR 

- adds `actor_id` to ActorHandleContext, so that message handler can get the actor_id, and send message to itself.

- also implements `std::error::Error` for `ActorRefError ` to make error handling easier.