### PR TITLE
feat: propagate current span over notify/send boundary

### DIFF
--- a/coerce/src/actor/message/mod.rs
+++ b/coerce/src/actor/message/mod.rs
@@ -56,7 +56,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::marker::PhantomData;
 use std::time::Instant;
 use tokio::sync::oneshot;
-use tracing::{Span, Instrument};
+use tracing::{Instrument, Span};
 
 pub trait Message: 'static + Sync + Send + Sized {
     type Result: 'static + Sync + Send;
@@ -119,7 +119,7 @@ where
     sender: Option<oneshot::Sender<M::Result>>,
     created_at: Instant,
     _a: PhantomData<A>,
-    parent_span : Span
+    parent_span: Span,
 }
 
 #[async_trait]
@@ -164,8 +164,11 @@ where
         let start = Instant::now();
 
         let msg = self.msg.take();
-        let result = actor.handle(msg.unwrap(), ctx).instrument(self.parent_span.clone()).await;
-        
+        let result = actor
+            .handle(msg.unwrap(), ctx)
+            .instrument(self.parent_span.clone())
+            .await;
+
         // ctx.last_message_timestamp = Some(start);
         let message_processing_took = start.elapsed();
 

--- a/coerce/src/actor/message/mod.rs
+++ b/coerce/src/actor/message/mod.rs
@@ -119,7 +119,7 @@ where
     sender: Option<oneshot::Sender<M::Result>>,
     created_at: Instant,
     _a: PhantomData<A>,
-    parent_span: Span,
+    sender_span: Span,
 }
 
 #[async_trait]
@@ -155,7 +155,7 @@ where
             sender,
             created_at: Instant::now(),
             _a: PhantomData,
-            parent_span: Span::current(),
+            sender_span: Span::current(),
         }
     }
 
@@ -166,7 +166,7 @@ where
         let msg = self.msg.take();
         let result = actor
             .handle(msg.unwrap(), ctx)
-            .instrument(self.parent_span.clone())
+            .instrument(self.sender_span.clone())
             .await;
 
         // ctx.last_message_timestamp = Some(start);


### PR DESCRIPTION
this allows the current span context to be used in the receiving actor when `notify` or `send` is used from a local actor ref

This fixes https://github.com/LeonHartley/Coerce-rs/issues/16

I haven't implemented a test, but have verified it in my local project.  I can implement a test if someone else can confirm that this is a correct approach

