### PR TITLE
feat: change new_actor, send and notify instrumentation to use level=debug

### DIFF
--- a/coerce/src/actor/mod.rs
+++ b/coerce/src/actor/mod.rs
@@ -758,7 +758,7 @@ impl<A: Actor> LocalActorRef<A> {
     /// ```
     ///
     /// [ActorStatus]: context::ActorStatus
-    #[instrument(skip(msg))]
+    #[instrument(skip(msg), level="debug")]
     pub async fn send<Msg: Message>(&self, msg: Msg) -> Result<Msg::Result, ActorRefErr>
     where
         A: Handler<Msg>,
@@ -815,7 +815,7 @@ impl<A: Actor> LocalActorRef<A> {
     ///
     /// ```
     ///
-    #[instrument(skip(msg))]
+    #[instrument(skip(msg), level="debug")]
     pub fn notify<Msg: Message>(&self, msg: Msg) -> Result<(), ActorRefErr>
     where
         A: Handler<Msg>,

--- a/coerce/src/actor/system.rs
+++ b/coerce/src/actor/system.rs
@@ -150,7 +150,7 @@ impl ActorSystem {
         self.new_actor(id, actor, ActorType::Anonymous).await
     }
 
-    #[instrument(skip(self, id, actor))]
+    #[instrument(skip(self, id, actor), level="debug")]
     pub async fn new_actor<I: IntoActorId, A: Actor>(
         &self,
         id: I,


### PR DESCRIPTION
I don't want these spans to appear at info level.  Ideally these would be driven off coerce feature `actor-tracing-info`, `actor-tracing-debug` and `actor-tracing-trace` but I an a new rust developer and am not sure how to achieve this