### PR TITLE
Unify error handling for non-registered remote messages sent via send & notify

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
+  
 name: coerce-rs tests
 
 jobs:

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -4,6 +4,9 @@ on:
       - master
       - feature/**
       - dev
+  pull_request:
+    branches:
+      - master
 name: coerce-rs tests
 
 jobs:

--- a/coerce/src/remote/system/actor.rs
+++ b/coerce/src/remote/system/actor.rs
@@ -243,10 +243,22 @@ impl RemoteActorSystem {
     }
 
     pub fn create_header<A: Actor, M: Message>(&self, id: &ActorId) -> Option<RemoteMessageHeader> {
-        self.handler_name::<A, M>()
+        let header = self
+            .handler_name::<A, M>()
             .map(|handler_type| RemoteMessageHeader {
                 actor_id: id.clone(),
                 handler_type,
-            })
+            });
+
+        if header.is_none() {
+            warn!(
+                    "no handler found, did you register it? (actor_id={} actor_type={} message_type={})",
+                    id,
+                    A::type_name(),
+                    M::type_name()
+                );
+        }
+
+        header
     }
 }


### PR DESCRIPTION
Currently, when I forget to register a handler (`.with_handler::<A, M>` at config time), and then subsequently try to send that message to a remote actor, the notify/send receives an ActorUnavailable error, which is kind of confusing. This PR adds a runtime log to help fix that pretty easy-to-do mistake.

Maybe it would be a good idea to also refactor error handling around create_request, currently it returns an Option with None for all failures