### PR TITLE
Feature/exact protobuf version

### DIFF
--- a/coerce/Cargo.toml
+++ b/coerce/Cargo.toml
@@ -87,7 +87,7 @@ hashring = { version = "0.3.0", optional = true }
 bytes = { version = "1.4.0", optional = true }
 byteorder = { version = "1.4.3", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
-protobuf = { version = "3.2.0", optional = true }
+protobuf = { version = "=3.2.0", optional = true }
 anyhow = { version = "1.0.71", optional = true }
 rand = "0.8.5"
 parking_lot = { version = "0.12.1", optional = true }

--- a/coerce/tests/test_actor_watching.rs
+++ b/coerce/tests/test_actor_watching.rs
@@ -10,8 +10,6 @@ use tokio::sync::oneshot::Sender;
 
 pub mod util;
 
-
-
 pub struct Watchdog {
     target: LocalActorRef<TestActor>,
     on_actor_terminated: Option<Sender<ActorTerminated>>,
@@ -36,7 +34,10 @@ impl Handler<ActorTerminated> for Watchdog {
 #[tokio::test]
 pub async fn test_actor_watch_notifications() {
     let system = ActorSystem::new();
-    let actor = TestActor::new().into_actor(Option::<ActorId>::None, &system).await.unwrap();
+    let actor = TestActor::new()
+        .into_actor(Option::<ActorId>::None, &system)
+        .await
+        .unwrap();
     let (tx, rx) = oneshot::channel();
     let _watchdog = Watchdog {
         target: actor.clone(),

--- a/coerce/tests/util/mod.rs
+++ b/coerce/tests/util/mod.rs
@@ -12,8 +12,8 @@ use std::str::FromStr;
 use tracing::Level;
 use tracing_subscriber::fmt::format::FmtSpan;
 
-use serde::{Deserialize, Serialize};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Copy, Clone)]
 pub enum TestActorStatus {


### PR DESCRIPTION
@LeonHartley  A very small change to the toml file to force the exact version of the protobuf dependency, and  a cargo fmt.

Hopefully solves https://github.com/LeonHartley/Coerce-rs/issues/32 in the future.